### PR TITLE
fix: use 'resource function' instead of 'resource_func' in error mess…

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ReachabilityAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ReachabilityAnalyzer.java
@@ -580,7 +580,7 @@ public class ReachabilityAnalyzer extends SimpleBLangNodeAnalyzer<ReachabilityAn
                     !data.hasFunctionTerminated) {
                 Location closeBracePos = getEndCharPos(funcNode.pos);
                 this.dlog.error(closeBracePos, DiagnosticErrorCode.INVOKABLE_MUST_RETURN,
-                        funcNode.getKind().toString().toLowerCase());
+                    funcNode.getKind() == NodeKind.RESOURCE_FUNC ? "resource function" : funcNode.getKind().toString().toLowerCase());
             } else if (isNeverReturn && !data.hasFunctionTerminated) {
                 this.dlog.error(funcNode.pos, DiagnosticErrorCode.THIS_FUNCTION_SHOULD_PANIC);
             }


### PR DESCRIPTION
## Purpose
Fixes #43815 - The error message BCE2095 was displaying `resource_func` 
instead of the correct term `resource function`.

## Approach
In `ReachabilityAnalyzer.java` line 583, `funcNode.getKind().toString()
.toLowerCase()` was converting the enum `RESOURCE_FUNC` to the string 
`"resource_func"`. Added a ternary check so when the kind is `RESOURCE_FUNC`, 
it uses `"resource function"` instead.

## Check List
- [x] Read the Contributing Guide